### PR TITLE
Update Joi peer possibilities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "^4.13.1"
   },
   "peerDependencies": {
-    "joi": "^10.6.0",
+    "joi": "^10.6.0 || 11.x || 12.x || ^13.0.x",
     "sequelize": "^4.2.0"
   },
   "babel": {


### PR DESCRIPTION
Joi introduces no change which would compromise sequelize-to-joi. 
I'm currently using your lib in production.