### PR TITLE
Patch default value

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -142,8 +142,8 @@ export default function (attribute) {
         joi = joi.allow(null);
     }
 
-    if (attribute.defaultValue && !_.isObject(attribute.defaultValue) && !_.isFunction(attribute.defaultValue)) {
-        joi = joi.default(attribute.defaultValue);
+    if (typeof attribute.defaultValue !== 'undefined' && !_lodash2.default.isObject(attribute.defaultValue) && !_lodash2.default.isFunction(attribute.defaultValue)) {
+        joi = joi.optional().default(attribute.defaultValue);
     }
 
     _.each(attribute.validate, (validator, key) => {

--- a/src/map.js
+++ b/src/map.js
@@ -142,7 +142,7 @@ export default function (attribute) {
         joi = joi.allow(null);
     }
 
-    if (typeof attribute.defaultValue !== 'undefined' && !_lodash2.default.isObject(attribute.defaultValue) && !_lodash2.default.isFunction(attribute.defaultValue)) {
+    if (typeof attribute.defaultValue !== 'undefined' && !_.isObject(attribute.defaultValue) && !_.isFunction(attribute.defaultValue)) {
         joi = joi.optional().default(attribute.defaultValue);
     }
 


### PR DESCRIPTION
Allows `defaultValue = false` for Boolean attributes and makes attribute optional, to use defaultValue, without requiring it to be null.
