### PR TITLE
Whenever string is nullable, allow empty strings

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -139,7 +139,11 @@ export default function (attribute) {
     if (attribute.allowNull === false) {
         joi = joi.required();
     } else {
-        joi = joi.allow(null);
+        if (joi.schemaType === 'string') {
+            joi = joi.allow('', null);
+        } else {
+            joi = joi.allow(null);
+        }
     }
 
     if (typeof attribute.defaultValue !== 'undefined' && !_.isObject(attribute.defaultValue) && !_.isFunction(attribute.defaultValue)) {


### PR DESCRIPTION
This eases REST client usage as hell whenever sequelize-to-joi is used for REST input validation.
Otherwise, every empty string is handled as an error... causing the client to do handle every empty string.